### PR TITLE
Make overhead and encoding len functions const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,49 @@ mod enc;
 pub use crate::dec::*;
 pub use crate::enc::*;
 
+/// Calculates the maximum overhead when encoding a message with the given length.
+/// The overhead is a maximum of [n/254] bytes (one in 254 bytes) rounded up.
+pub const fn max_encoding_overhead(source_len: usize) -> usize {
+    (source_len + 254 - 1) / 254
+}
+
 /// Calculates the maximum possible size of an encoded message given the length
 /// of the source message. This may be useful for calculating how large the
 /// `dest` buffer needs to be in the encoding functions.
-pub fn max_encoding_length(source_len: usize) -> usize {
-    source_len + (source_len / 254) + if source_len % 254 > 0 { 1 } else { 0 }
+pub const fn max_encoding_length(source_len: usize) -> usize {
+    source_len + max_encoding_overhead(source_len)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{max_encoding_length, max_encoding_overhead};
+
+    // Usable in const context
+    const ENCODED_BUF: [u8; max_encoding_length(5)] = [0; max_encoding_length(5)];
+
+    #[test]
+    fn test_buf_len() {
+        assert_eq!(ENCODED_BUF.len(), 6);
+    }
+
+    #[test]
+    fn test_overhead_empty() {
+        assert_eq!(max_encoding_overhead(0), 0);
+    }
+
+    #[test]
+    fn test_overhead_one() {
+        assert_eq!(max_encoding_overhead(1), 1);
+    }
+
+    #[test]
+    fn test_overhead_larger() {
+        assert_eq!(max_encoding_overhead(253), 1);
+        assert_eq!(max_encoding_overhead(254), 1);
+    }
+
+    #[test]
+    fn test_overhead_two() {
+        assert_eq!(max_encoding_overhead(255), 2);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,15 @@ pub use crate::enc::*;
 
 /// Calculates the maximum overhead when encoding a message with the given length.
 /// The overhead is a maximum of [n/254] bytes (one in 254 bytes) rounded up.
+#[inline]
 pub const fn max_encoding_overhead(source_len: usize) -> usize {
-    (source_len + 254 - 1) / 254
+    source_len.div_ceil(254)
 }
 
 /// Calculates the maximum possible size of an encoded message given the length
 /// of the source message. This may be useful for calculating how large the
 /// `dest` buffer needs to be in the encoding functions.
+#[inline]
 pub const fn max_encoding_length(source_len: usize) -> usize {
     source_len + max_encoding_overhead(source_len)
 }


### PR DESCRIPTION
It would be nice if the `max_encoding_length` and a new `max_encoding_overhead` functions could be used when declaring and initializing buffers (e.g. encoded data buffer).

I made those functions constant to allow this. I also added a separate function to only calculate the overhead and added a few basic tests.

I did not see a CHANGELOG to add those additions / improvements.
What do you think about adding a CHANGELOG?