### PR TITLE
Possible encoder bugfix

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -67,7 +67,10 @@ fn stream_roundtrip() {
             for c in dest[0..sz_en].chunks(11) {
                 cd.push(c).unwrap();
             }
-            let sz_msg = cd.feed(0).unwrap().unwrap();
+            let sz_msg = match cd.feed(0) {
+                Ok(sz_msg) => sz_msg.unwrap(),
+                Err(written) => panic!("decoding failed, {} bytes written to output", written),
+            };
             sz_msg
         };
 
@@ -265,4 +268,18 @@ fn issue_15() {
 
     println!("{:?}  {:?}  {:?}", my_string_buf, cobs_buf, decoded_buf);
     assert_eq!(my_string_buf, decoded_buf);
+}
+
+#[test]
+fn issue_19_test_254_block_all_ones() {
+    let src: [u8; 254] = [1; 254];
+    let mut dest: [u8; 256] = [0; 256];
+    let encode_len = encode(&src, &mut dest);
+    //println!("Encoded buf [0..100]: {:x?}", &dest[0..100]);
+    //println!("Encoded buf [100..end]: {:x?}", &dest[100..]);
+    assert_eq!(encode_len, 255);
+    let mut decoded: [u8; 254] = [1; 254];
+    let decoded_len = decode(&dest, &mut decoded).expect("decoding failed");
+    assert_eq!(decoded_len, 254);
+    assert_eq!(&src, &decoded);
 }


### PR DESCRIPTION
Possible fix for https://github.com/jamesmunns/cobs.rs/issues/19 .

I do not have proficient understanding of the COBS protocol yet so it would be good if this is thoroughly reviewed.
I compared the Rust implementation with the C implementation from [wikipedia](https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing) and I saw that there is a similar process of an encode pointer double increment. However, this is only done if the algorithm is not finished yet, more explicitely when length is not 0.

In Rust, this is a bit more complicated. I figured that the state machine has to remember when there might be the possibility that the encoding process is done and the destination index does not need to be incremented anymore. I did this with a boolean flag for the encoder struct. If push is called again, then the index needs to be incremented, and this is done before it starts iterating over the data to be pushed.

I ran all the existing tests again and also added a new one for the issue case.