### PR TITLE
`alloc` feature that is still `no_std`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ script:
 
 # Check for no_std compatibility by building for an embedded target
 - cargo build --no-default-features --target=thumbv7em-none-eabihf
+- cargo build --no-default-features --features=alloc --target=thumbv7em-none-eabihf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ edition = "2021"
 
 [features]
 default = ["use_std"]
-use_std = ["thiserror/std"]
+use_std = ["alloc", "thiserror/std"]
+alloc = []
 
 [dependencies]
 thiserror = { version = "2", default-features = false }

--- a/src/dec.rs
+++ b/src/dec.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "alloc")]
+use alloc::{vec, vec::Vec};
+
 /// The [`CobsDecoder`] type is used to decode a stream of bytes to a
 /// given mutable output slice. This is often useful when heap data
 /// structures are not available, or when not all message bytes are
@@ -338,7 +341,7 @@ pub fn decode_in_place_with_sentinel(buff: &mut [u8], sentinel: u8) -> Result<us
     decode_in_place(buff)
 }
 
-#[cfg(feature = "use_std")]
+#[cfg(feature = "alloc")]
 /// Decodes the `source` buffer into a vector.
 pub fn decode_vec(source: &[u8]) -> Result<Vec<u8>, DecodeError> {
     let mut decoded = vec![0; source.len()];
@@ -347,7 +350,7 @@ pub fn decode_vec(source: &[u8]) -> Result<Vec<u8>, DecodeError> {
     Ok(decoded)
 }
 
-#[cfg(feature = "use_std")]
+#[cfg(feature = "alloc")]
 /// Decodes the `source` buffer into a vector with an arbitrary sentinel value.
 pub fn decode_vec_with_sentinel(source: &[u8], sentinel: u8) -> Result<Vec<u8>, DecodeError> {
     let mut decoded = vec![0; source.len()];

--- a/src/enc.rs
+++ b/src/enc.rs
@@ -1,5 +1,8 @@
-#[cfg(feature = "use_std")]
-use crate::max_encoding_length;
+#[cfg(feature = "alloc")]
+use {
+    crate::max_encoding_length,
+    alloc::{vec, vec::Vec},
+};
 
 /// The [`CobsEncoder`] type is used to encode a stream of bytes to a
 /// given mutable output slice. This is often useful when heap data
@@ -238,7 +241,7 @@ pub fn encode_with_sentinel(source: &[u8], dest: &mut [u8], sentinel: u8) -> usi
     encoded_size
 }
 
-#[cfg(feature = "use_std")]
+#[cfg(feature = "alloc")]
 /// Encodes the `source` buffer into a vector, using the [encode] function.
 pub fn encode_vec(source: &[u8]) -> Vec<u8> {
     let mut encoded = vec![0; max_encoding_length(source.len())];
@@ -247,7 +250,7 @@ pub fn encode_vec(source: &[u8]) -> Vec<u8> {
     encoded
 }
 
-#[cfg(feature = "use_std")]
+#[cfg(feature = "alloc")]
 /// Encodes the `source` buffer into a vector with an arbitrary sentinel value, using the
 /// [encode_with_sentinel] function.
 pub fn encode_vec_with_sentinel(source: &[u8], sentinel: u8) -> Vec<u8> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(feature = "use_std"), no_std)]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 // In the future, don't do this.
 mod dec;
 mod enc;


### PR DESCRIPTION
The `use_std` feature seems to be used to get access to dynamically allocated data collections (i.e. `Vec`). This however precludes the ability to use function such as `encode_vec()` in a no_std environment that has a dynamic allocator. I was able to transition to a having an `alloc` feature that allows access to all this while remaining `no_std`. The original `use_std` feature was left in place to avoid breaking changes for users of this crate. 

Unfortunately `cargo fmt` created a decent bit of noise in the pull request. If that is unacceptable let me know I can make the same changes without letting `cargo fmt` run.

Let me know if you have any question or suggestions