### PR TITLE
chore: update quickcheck dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ default = ["use_std"]
 use_std = []
 
 [dev-dependencies]
-quickcheck = "^0.5.0"
+quickcheck = "1"


### PR DESCRIPTION
Update the quickcheck dependency to "^1.0.0". The caret will not do a major semver update and the current version of quickcheck is 1.0.3.