### PR TITLE
Empty input encoded into single 0x01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # [unreleased]
 
+## Fixed
+
+- The encoder functions will now encode empty input into a single 0x01 byte.
+  [#49](https://github.com/jamesmunns/cobs.rs/pull/49)
+
 # [v0.3.0] 2025-01-31
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobs"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Allen Welkie <>", "James Munns <james@onevariable.com>"]
 license = "MIT OR Apache-2.0"
 description = """

--- a/src/dec.rs
+++ b/src/dec.rs
@@ -183,7 +183,7 @@ impl<'a> CobsDecoder<'a> {
     ///
     /// * Ok(None) - State machine okay, more data needed
     /// * Ok(Some((N, M))) - A message of N bytes was successfully decoded,
-    ///     using M bytes from `data` (and earlier data)
+    ///   using M bytes from `data` (and earlier data)
     /// * Err([DecodeError]) - Message decoding failed
     ///
     /// NOTE: Sentinel value must be included in the input to this function for the

--- a/src/enc.rs
+++ b/src/enc.rs
@@ -1,7 +1,7 @@
-/// The [`CobsEncoder`] type is used to encode a stream of bytes to a
-/// given mutable output slice. This is often useful when heap data
-/// structures are not available, or when not all message bytes are
-/// received at a single point in time.
+/// The [`CobsEncoder`] type is used to encode a stream of bytes to a given mutable output slice.
+///
+/// This is often useful when heap data structures are not available, or when not all message bytes
+/// are received at a single point in time.
 #[derive(Debug)]
 pub struct CobsEncoder<'a> {
     dest: &'a mut [u8],
@@ -16,10 +16,9 @@ pub struct CobsEncoder<'a> {
 #[error("out of bounds error during encoding")]
 pub struct DestBufTooSmallError;
 
-/// The [`EncoderState`] is used to track the current state of a
-/// streaming encoder. This struct does not contain the output buffer
-/// (or a reference to one), and can be used when streaming the encoded
-/// output to a custom data type
+/// The [`EncoderState`] is used to track the current state of a streaming encoder. This struct
+/// does not contain the output buffer (or a reference to one), and can be used when streaming the
+/// encoded output to a custom data type
 ///
 /// **IMPORTANT NOTE**: When implementing a custom streaming encoder,
 /// the [`EncoderState`] state machine assumes that the output buffer
@@ -102,7 +101,7 @@ impl EncoderState {
 }
 
 impl<'a> CobsEncoder<'a> {
-    /// Create a new streaming Cobs Encoder
+    /// Create a new streaming Cobs Encoder.
     pub fn new(out_buf: &'a mut [u8]) -> CobsEncoder<'a> {
         CobsEncoder {
             dest: out_buf,
@@ -159,15 +158,15 @@ impl<'a> CobsEncoder<'a> {
         Ok(())
     }
 
-    /// Complete encoding of the output message. Does NOT terminate
-    /// the message with the sentinel value
+    /// Complete encoding of the output message. Does NOT terminate the message with the sentinel
+    /// value.
     pub fn finalize(self) -> usize {
-        if self.dest_idx == 1 {
-            return 0;
-        }
-
         // Get the last index that needs to be fixed
-        let (idx, mval) = self.state.finalize();
+        let (idx, mval) = if self.dest_idx == 0 {
+            (0, 0x01)
+        } else {
+            self.state.finalize()
+        };
 
         // If the current code index is outside of the destination slice,
         // we do not need to write it out

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,9 @@ pub use crate::enc::*;
 /// The overhead is a maximum of [n/254] bytes (one in 254 bytes) rounded up.
 #[inline]
 pub const fn max_encoding_overhead(source_len: usize) -> usize {
+    if source_len == 0 {
+        return 1;
+    }
     source_len.div_ceil(254)
 }
 
@@ -68,7 +71,7 @@ mod tests {
 
     #[test]
     fn test_overhead_empty() {
-        assert_eq!(max_encoding_overhead(0), 0);
+        assert_eq!(max_encoding_overhead(0), 1);
     }
 
     #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -69,6 +69,7 @@ fn stream_roundtrip() {
 
 #[test]
 fn test_max_encoding_length() {
+    assert_eq!(max_encoding_length(0), 1);
     assert_eq!(max_encoding_length(253), 254);
     assert_eq!(max_encoding_length(254), 255);
     assert_eq!(max_encoding_length(255), 257);
@@ -81,13 +82,18 @@ fn test_encode_0() {
     // An empty input is encoded as no characters.
     let mut output = [0xFFu8; 16];
     let used = encode(&[], &mut output);
-    assert_eq!(used, 0);
-    assert_eq!(output.as_slice(), &[0xFFu8; 16]);
+    assert_eq!(used, 1);
+    assert_eq!(output[0], 0x01);
 }
 
 #[test]
 fn test_encode_1() {
     test_pair(&[10, 11, 0, 12], &[3, 10, 11, 2, 12])
+}
+
+#[test]
+fn test_encode_empty() {
+    test_pair(&[], &[1])
 }
 
 #[test]


### PR DESCRIPTION
Fixes #47 and is related to #16 .

I bumped the version.
While this might be considered a bugfix, it might break user code relying on the encoding of empty data to be emtpy as well.