### PR TITLE
Cargo, benches: add random encoding and decoding benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,12 @@ heapless = "0.9"
 
 [dev-dependencies]
 quickcheck = "1"
+criterion = { version = "0.8" }
+rand = "0.9"
+
+[[bench]]
+name = "main"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,0 +1,46 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::Rng;
+
+// Benchmarks the encoding speed for random input.
+fn bench_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("encode");
+
+    for size in [16, 256, 4096, 65536, 262144, 1048576, 4194304] {
+        let data: Vec<u8> = rand::rng().random_iter().take(size).collect();
+        let mut buffer = vec![0u8; cobs::max_encoding_length(size)];
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| {
+                cobs::encode(data, &mut buffer);
+            });
+        });
+    }
+    group.finish();
+}
+
+// Benchmarks the decoding speed for random input.
+fn bench_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode");
+
+    for size in [16, 256, 4096, 65536, 262144, 1048576, 4194304] {
+        let data: Vec<u8> = rand::rng().random_iter().take(size).collect();
+        let mut encoded = vec![0u8; cobs::max_encoding_length(size)];
+
+        let len = cobs::encode(&data, &mut encoded);
+        encoded.truncate(len);
+
+        let mut buffer = vec![0u8; size];
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &encoded, |b, encoded| {
+            b.iter(|| {
+                cobs::decode(encoded, &mut buffer).unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_encode, bench_decode);
+criterion_main!(benches);


### PR DESCRIPTION
This PR adds a set of encoding and decoding benchmarks through `criterion`. This should help investigating and fixing bottlenecks.

You can run them with:

```
% cargo bench -- --quiet

encode/16               time:   [10.101 ns 10.173 ns 10.253 ns]
                        thrpt:  [1.4533 GiB/s 1.4648 GiB/s 1.4753 GiB/s]
encode/256              time:   [155.40 ns 156.34 ns 157.37 ns]
                        thrpt:  [1.5150 GiB/s 1.5250 GiB/s 1.5342 GiB/s]
encode/4096             time:   [2.4068 µs 2.4196 µs 2.4340 µs]
                        thrpt:  [1.5673 GiB/s 1.5766 GiB/s 1.5850 GiB/s]
encode/65536            time:   [39.093 µs 39.250 µs 39.412 µs]
                        thrpt:  [1.5486 GiB/s 1.5550 GiB/s 1.5613 GiB/s]
encode/262144           time:   [157.16 µs 157.75 µs 158.41 µs]
                        thrpt:  [1.5412 GiB/s 1.5476 GiB/s 1.5534 GiB/s]
encode/1048576          time:   [626.03 µs 628.54 µs 631.40 µs]
                        thrpt:  [1.5467 GiB/s 1.5537 GiB/s 1.5599 GiB/s]
encode/4194304          time:   [2.5377 ms 2.5471 ms 2.5571 ms]
                        thrpt:  [1.5276 GiB/s 1.5336 GiB/s 1.5393 GiB/s]

decode/16               time:   [17.720 ns 17.796 ns 17.878 ns]
                        thrpt:  [853.51 MiB/s 857.43 MiB/s 861.11 MiB/s]
decode/256              time:   [275.67 ns 278.34 ns 281.52 ns]
                        thrpt:  [867.23 MiB/s 877.12 MiB/s 885.64 MiB/s]
decode/4096             time:   [4.1439 µs 4.1748 µs 4.2113 µs]
                        thrpt:  [927.55 MiB/s 935.68 MiB/s 942.66 MiB/s]
decode/65536            time:   [66.592 µs 66.922 µs 67.312 µs]
                        thrpt:  [928.51 MiB/s 933.93 MiB/s 938.55 MiB/s]
decode/262144           time:   [267.94 µs 269.85 µs 272.14 µs]
                        thrpt:  [918.64 MiB/s 926.45 MiB/s 933.06 MiB/s]
decode/1048576          time:   [1.0910 ms 1.1016 ms 1.1137 ms]
                        thrpt:  [897.90 MiB/s 907.78 MiB/s 916.63 MiB/s]
decode/4194304          time:   [4.3030 ms 4.3221 ms 4.3437 ms]
                        thrpt:  [920.88 MiB/s 925.47 MiB/s 929.58 MiB/s]
```