### PR TITLE
Decoding branch reorg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,12 @@ heapless = "0.9"
 
 [dev-dependencies]
 quickcheck = "1"
+criterion = { version = "0.8" }
+rand = "0.9"
+
+[[bench]]
+name = "main"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,0 +1,46 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::Rng;
+
+// Benchmarks the encoding speed for random input.
+fn bench_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("encode");
+
+    for size in [16, 256, 4096, 65536, 262144, 1048576, 4194304] {
+        let data: Vec<u8> = rand::rng().random_iter().take(size).collect();
+        let mut buffer = vec![0u8; cobs::max_encoding_length(size)];
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| {
+                cobs::encode(data, &mut buffer);
+            });
+        });
+    }
+    group.finish();
+}
+
+// Benchmarks the decoding speed for random input.
+fn bench_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode");
+
+    for size in [16, 256, 4096, 65536, 262144, 1048576, 4194304] {
+        let data: Vec<u8> = rand::rng().random_iter().take(size).collect();
+        let mut encoded = vec![0u8; cobs::max_encoding_length(size)];
+
+        let len = cobs::encode(&data, &mut encoded);
+        encoded.truncate(len);
+
+        let mut buffer = vec![0u8; size];
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &encoded, |b, encoded| {
+            b.iter(|| {
+                cobs::decode(encoded, &mut buffer).unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_encode, bench_decode);
+criterion_main!(benches);

--- a/src/dec.rs
+++ b/src/dec.rs
@@ -1,3 +1,5 @@
+use crate::DecoderState::Idle;
+
 /// The [`DecoderState`] is used to track the current state of a
 /// streaming decoder. This struct does not contain the output buffer
 /// (or a reference to one), and can be used when streaming the decoded
@@ -70,7 +72,65 @@ impl DecoderState {
     pub fn feed(&mut self, data: u8) -> Result<DecodeResult, DecodeError> {
         use DecodeResult::*;
         use DecoderState::*;
+
         let (ret, state) = match (&self, data) {
+            (Grab(i), n) => {
+                if *i > 0 && n > 0 {
+                    // We have not yet reached the end of a data run, decrement the run
+                    // counter, and place the byte into the decoded output
+                    (Ok(DataContinue(n)), Grab(*i - 1))
+                } else if *i == 0 {
+                    match n {
+                        // We have reached the end of a data run indicated by an overhead
+                        // byte, AND we have received the message terminator. This was a
+                        // well framed message!
+                        0x00 => (Ok(DataComplete), Idle),
+
+                        // We have reached the end of a data run indicated by an overhead
+                        // byte, and the next segment of 254 bytes will have no modified
+                        // sentinel bytes
+                         0xFF => (Ok(DataContinue(0)), GrabChain(0xFE)),
+
+                        // We have reached the end of a data run indicated by an overhead
+                        // byte, and we will treat this byte as a modified sentinel byte.
+                        // place the sentinel byte in the output, and begin processing the
+                        // next non-sentinel sequence
+                        n => (Ok(DataContinue(0)), Grab(n - 1)),
+                    }
+                } else {
+                    // We were not expecting the sequence to terminate, but here we are.
+                    // Report an error due to early terminated message
+                    (Err(DecodeError::InvalidFrame { decoded_bytes: 0 }), Idle)
+                }
+            }
+
+            (GrabChain(i), n) => {
+                if *i > 0 && n > 0 {
+                    // We have not yet reached the end of a data run, decrement the run
+                    // counter, and place the byte into the decoded output
+                   (Ok(DataContinue(n)), GrabChain(*i - 1))
+                } else if *i == 0 {
+                    match n {
+                        // We have reached the end of a data run indicated by an overhead
+                        // byte, AND we have received the message terminator. This was a
+                        // well framed message!
+                        0x00 => (Ok(DataComplete), Idle),
+
+                        // We have reached the end of a data run, and we will begin another
+                        // data run with an overhead byte expected at the end
+                        0xFF => (Ok(NoData), GrabChain(0xFE)),
+
+                        // We have reached the end of a data run, and we will expect `n` data
+                        // bytes unmodified, followed by a sentinel byte that must be modified
+                        n => (Ok(NoData), Grab(n - 1)),
+                    }
+                } else {
+                    // We were not expecting the sequence to terminate, but here we are.
+                    // Report an error due to early terminated message
+                    (Err(DecodeError::InvalidFrame { decoded_bytes: 0 }), Idle)
+                }
+            }
+
             // Currently Idle, received a terminator, ignore, stay idle
             (Idle, 0x00) => (Ok(NoData), Idle),
 
@@ -82,51 +142,6 @@ impl DecoderState {
             // Currently Idle, received a byte indicating there will be a
             // zero that must be modified in the next 1..=254 bytes
             (Idle, n) => (Ok(DataStart), Grab(n - 1)),
-
-            // We have reached the end of a data run indicated by an overhead
-            // byte, AND we have received the message terminator. This was a
-            // well framed message!
-            (Grab(0), 0x00) => (Ok(DataComplete), Idle),
-
-            // We have reached the end of a data run indicated by an overhead
-            // byte, and the next segment of 254 bytes will have no modified
-            // sentinel bytes
-            (Grab(0), 0xFF) => (Ok(DataContinue(0)), GrabChain(0xFE)),
-
-            // We have reached the end of a data run indicated by an overhead
-            // byte, and we will treat this byte as a modified sentinel byte.
-            // place the sentinel byte in the output, and begin processing the
-            // next non-sentinel sequence
-            (Grab(0), n) => (Ok(DataContinue(0)), Grab(n - 1)),
-
-            // We were not expecting the sequence to terminate, but here we are.
-            // Report an error due to early terminated message
-            (Grab(_), 0) => (Err(DecodeError::InvalidFrame { decoded_bytes: 0 }), Idle),
-
-            // We have not yet reached the end of a data run, decrement the run
-            // counter, and place the byte into the decoded output
-            (Grab(i), n) => (Ok(DataContinue(n)), Grab(*i - 1)),
-
-            // We have reached the end of a data run indicated by an overhead
-            // byte, AND we have received the message terminator. This was a
-            // well framed message!
-            (GrabChain(0), 0x00) => (Ok(DataComplete), Idle),
-
-            // We have reached the end of a data run, and we will begin another
-            // data run with an overhead byte expected at the end
-            (GrabChain(0), 0xFF) => (Ok(NoData), GrabChain(0xFE)),
-
-            // We have reached the end of a data run, and we will expect `n` data
-            // bytes unmodified, followed by a sentinel byte that must be modified
-            (GrabChain(0), n) => (Ok(NoData), Grab(n - 1)),
-
-            // We were not expecting the sequence to terminate, but here we are.
-            // Report an error due to early terminated message
-            (GrabChain(_), 0) => (Err(DecodeError::InvalidFrame { decoded_bytes: 0 }), Idle),
-
-            // We have not yet reached the end of a data run, decrement the run
-            // counter, and place the byte into the decoded output
-            (GrabChain(i), n) => (Ok(DataContinue(n)), GrabChain(*i - 1)),
         };
 
         *self = state;

--- a/src/dec.rs
+++ b/src/dec.rs
@@ -1,5 +1,3 @@
-use crate::DecoderState::Idle;
-
 /// The [`DecoderState`] is used to track the current state of a
 /// streaming decoder. This struct does not contain the output buffer
 /// (or a reference to one), and can be used when streaming the decoded
@@ -89,7 +87,7 @@ impl DecoderState {
                         // We have reached the end of a data run indicated by an overhead
                         // byte, and the next segment of 254 bytes will have no modified
                         // sentinel bytes
-                         0xFF => (Ok(DataContinue(0)), GrabChain(0xFE)),
+                        0xFF => (Ok(DataContinue(0)), GrabChain(0xFE)),
 
                         // We have reached the end of a data run indicated by an overhead
                         // byte, and we will treat this byte as a modified sentinel byte.
@@ -108,7 +106,7 @@ impl DecoderState {
                 if *i > 0 && n > 0 {
                     // We have not yet reached the end of a data run, decrement the run
                     // counter, and place the byte into the decoded output
-                   (Ok(DataContinue(n)), GrabChain(*i - 1))
+                    (Ok(DataContinue(n)), GrabChain(*i - 1))
                 } else if *i == 0 {
                     match n {
                         // We have reached the end of a data run indicated by an overhead
@@ -631,7 +629,6 @@ pub type DecodingResult = DecodeReport;
 
 #[cfg(test)]
 mod tests {
-
     use crate::{encode, encode_vec_including_sentinels};
 
     use super::*;


### PR DESCRIPTION
Supersedes https://github.com/jamesmunns/cobs.rs/pull/66
Builds on https://github.com/jamesmunns/cobs.rs/pull/67

This PR reorgs the decoding evaluation statements to run the most probably branches first and then the least probably ones. It results in a 20% speed improvement.

The PR is similar to my previous one, just doesn't have the duplicated statements, rather it did a bit of nesting.

**PR**

```
decode/16               time:   [15.244 ns 15.325 ns 15.423 ns]
                        thrpt:  [989.36 MiB/s 995.65 MiB/s 1001.0 MiB/s]
decode/256              time:   [224.40 ns 225.55 ns 226.80 ns]
                        thrpt:  [1.0512 GiB/s 1.0570 GiB/s 1.0625 GiB/s]
decode/4096             time:   [3.5846 µs 3.6059 µs 3.6281 µs]
                        thrpt:  [1.0514 GiB/s 1.0579 GiB/s 1.0642 GiB/s]
decode/65536            time:   [57.867 µs 58.157 µs 58.483 µs]
                        thrpt:  [1.0436 GiB/s 1.0495 GiB/s 1.0548 GiB/s]
decode/262144           time:   [229.97 µs 231.12 µs 232.50 µs]
                        thrpt:  [1.0501 GiB/s 1.0563 GiB/s 1.0616 GiB/s]
decode/1048576          time:   [918.05 µs 924.97 µs 932.95 µs]
                        thrpt:  [1.0467 GiB/s 1.0558 GiB/s 1.0637 GiB/s]
decode/4194304          time:   [3.6647 ms 3.6801 ms 3.6970 ms]
                        thrpt:  [1.0566 GiB/s 1.0615 GiB/s 1.0659 GiB/s]
```

**main**

```
decode/16               time:   [17.527 ns 17.619 ns 17.726 ns]
                        thrpt:  [860.79 MiB/s 866.02 MiB/s 870.61 MiB/s]
decode/256              time:   [260.28 ns 261.75 ns 263.44 ns]
                        thrpt:  [926.72 MiB/s 932.73 MiB/s 937.99 MiB/s]
decode/4096             time:   [4.2201 µs 4.2409 µs 4.2655 µs]
                        thrpt:  [915.79 MiB/s 921.10 MiB/s 925.63 MiB/s]
decode/65536            time:   [67.987 µs 68.354 µs 68.751 µs]
                        thrpt:  [909.08 MiB/s 914.35 MiB/s 919.29 MiB/s]
decode/262144           time:   [271.03 µs 272.51 µs 274.25 µs]
                        thrpt:  [911.58 MiB/s 917.41 MiB/s 922.42 MiB/s]
decode/1048576          time:   [1.0911 ms 1.0963 ms 1.1024 ms]
                        thrpt:  [907.12 MiB/s 912.17 MiB/s 916.47 MiB/s]
decode/4194304          time:   [4.3322 ms 4.3502 ms 4.3705 ms]
                        thrpt:  [915.22 MiB/s 919.50 MiB/s 923.32 MiB/s]
```